### PR TITLE
Refer to security advisories in default gh org security doc

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,17 @@
 
 This document defines security reporting, handling, and disclosure information for the Flux project and community.
 
-## Report a Vulnerability
+## Security Advisories
+
+Here is an overview of all our published security advisories.
+
+Date | CVE | Title | Severity | Affected version(s) | Reported by
+---- | --- | ----- | -------- | ------------------- | -----------
+2021-11-10 | CVE-2021-41254 | [Privilege escalation to cluster admin on multi-tenant Flux](https://github.com/fluxcd/kustomize-controller/security/advisories/GHSA-35rf-v2jv-gfg7) | High | < 0.18.0 | ADA Logics
+
+## Security Process
+
+### Report a Vulnerability
 
 We're very thankful for – and if desired happy to credit – security researchers and users who report vulnerabilities to the Flux community.
 
@@ -12,7 +22,7 @@ We're very thankful for – and if desired happy to credit – security researc
 - The Security Team will fix the issue as soon as possible and coordinate a release date with you.
 - You will be able to choose if you want public acknowledgement of your effort and how you would like to be credited.
 
-## Security Team
+### Security Team
 
 Current Security Team members:
 
@@ -21,7 +31,7 @@ Current Security Team members:
 | Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155 |
 | Hidde Beydals | [@hiddeco](https://github.com/hiddeco) | <https://keybase.io/hidde/pgp_keys.asc> | C910 7A9B 55A4 DD77 062B 9731 B6E3 6A6A C54A CD59 |
 
-## Handling
+### Handling
 
 - All reports are thoroughly investigated by the Security Team.
 - Any vulnerability information shared with the Security Team will not be shared with others unless it is necessary to fix the issue.
@@ -29,7 +39,7 @@ Current Security Team members:
 - As the security issue moves through the identification and resolution process, the reporter will be notified.
 - Additional questions about the vulnerability may also be asked of the reporter.
 
-## Disclosures
+### Disclosures
 
 Vulnerability disclosures are emailed to the Flux Dev mailing list <https://lists.cncf.io/g/cncf-flux-dev> and announced publicly.
 Disclosures will contain an overview, details about the vulnerability, a fix that will typically be an update, and optionally a workaround if one is available.


### PR DESCRIPTION
Not high-priority but good follow-up