### PR TITLE
Add Paulo Gomes to the security team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,7 @@ Current Security Team members:
 | -- | -- | -- | -- |
 | Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155 |
 | Hidde Beydals | [@hiddeco](https://github.com/hiddeco) | <https://keybase.io/hidde/pgp_keys.asc> | C910 7A9B 55A4 DD77 062B 9731 B6E3 6A6A C54A CD59 |
+| Paulo Gomes | [@pjbgf](https://github.com/pjbgf) | <https://keybase.io/pjbgf/pgp_keys.asc> | 6C17 B119 D8C9 6768 4C80 E802 9995 2338 70E9 9BEE |
 
 ### Handling
 


### PR DESCRIPTION
Reasoning:
- Maintainer of some Flux repositories, [expanding to Flux2](https://github.com/fluxcd/flux2/pull/2638).
- Background working with Kubernetes and cloud security.
- Focused on various security related PRs/Issues across Flux repositories.
- Keen on working on research and improving processes around Flux's security.