### PR TITLE
Add Coordinated Vulnerability Disclosure details

### DIFF
--- a/CVD_LIST.md
+++ b/CVD_LIST.md
@@ -1,0 +1,42 @@
+# Coordinated Vulnerability Disclosure List
+
+This list is used to provide actionable information to multiple vendors at once.
+This list is not intended for individuals to find out about security issues.
+
+## Embargo Policy
+
+This policy forbids members of this project's [security contacts] and others
+defined below from sharing information outside of the [security contacts] and this
+listing without need-to-know and advance notice.
+
+The information members and others receive from the list defined below must:
+
+* not be made public,
+* not be shared,
+* not be hinted at,
+* must be kept confidential and close held
+
+Except with the list's explicit approval. This holds true until the public
+disclosure date/time that was agreed upon by the list.
+
+If information is inadvertently shared beyond what is allowed by this policy,
+you are REQUIRED to inform the [security contacts] of exactly what
+information leaked and to whom. A retrospective will take place after the leak
+so we can assess how to not make this mistake in the future.
+
+Violation of this policy will result in the immediate removal and subsequent
+replacement of you from this list or the [security contacts].
+
+## Membership Criteria
+
+To be eligible for joining the CVD list, you should:
+
+1. Have an actively monitored security email alias for your organization.
+2. Support active Flux instances to users beyond your own organization.
+3. Accept the [Embargo Policy](#embargo-policy) that is outlined above.
+
+[security contacts]: https://github.com/fluxcd/.github/blob/main/SECURITY.md
+
+### Request to Join
+
+Submit a request [here](https://docs.google.com/forms/d/1RJRUSwHUeKwJfZdcAzIkyKD4TeAweLLjXZkcN-uVDqA).

--- a/CVD_MESSAGE_TEMPLATE.md
+++ b/CVD_MESSAGE_TEMPLATE.md
@@ -1,0 +1,68 @@
+# Notice of Embargo
+
+This is an embargoed notification that a vulnerability has been discovered in
+Flux. This notice has been sent to subscribed distributors and service
+providers in order to allow for timely patching. You are receiving this
+notification as you have agreed to abide by the [embargo policy] on this
+project. Do not forward this information to other parties without complying with
+the instructions of the [embargo policy].
+
+## Summary
+
+*2-3 sentences describing the vulnerability using technical details. This should
+only contain enough information to be able to make a quick determination of what
+the vulnerability is about.*
+
+### CVE
+
+#### $CVE-NUMBER
+
+### Versions
+
+#### $CONTROLLER-NAME $VERSION_RANGE
+#### FLUX2 CLI $VERSION_RANGE
+
+### $CVSS $SEVERITY [low, medium, high, critical]
+
+*Provide an attack scenario or other information to explain the risk associated.
+Use details gathered from the triage.*
+
+Further information about the scoring details can be found at [cvss-calculator].
+
+[cvss-calculator]: https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator
+
+### Proof of Concept
+
+*Provide exact code or command lines in order to offer usable, precise, and
+repeatable methods for a subscriber to reproduce the problem and test fixes and
+mitigations.*
+
+### Remediation and Mitigation
+
+*Provide information on the known remediation or planned patch. Be sure to list
+when it will be available or links to where the patch will be available.*
+
+### Additional information
+
+*If you have additional information to provide, be sure to include it here.*
+
+## Timeline
+
+**Date reported:** DD MMM YYYY
+**Date fixed:** DD MMM YYYY
+**Date to be disclosed:** DD MMM YYYY
+
+### Public disclosure date: $DATE $TIME $TIMEZONE
+
+**Do not:**
+
+* make this information public,
+* issue communications hinting at or regarding this,
+* share this with others,
+* issue public patches before the disclosure date
+
+This list will be notified immediately if the disclosure date is at risk or
+changes. Questions should be directed to the [security contacts].
+
+[embargo policy]: https://github.com/fluxcd/.github/CVD_LIST.md#embargo-policy
+[security contacts]: https://github.com/fluxcd/.github/blob/main/SECURITY.md


### PR DESCRIPTION
This is largely based on CNCF's embargo policies, with some influence from Kubernetes Private Distributors List.

References:
https://github.com/cncf/tag-security/tree/main/project-resources/templates
https://github.com/kubernetes/committee-security-response/blob/main/private-distributors-list.md