### PR TITLE
Add Matheus Pimenta to the security team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,7 @@ Current Security Team members:
 | Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155 |
 | Hidde Beydals | [@hiddeco](https://github.com/hiddeco) | <https://keybase.io/hidde/pgp_keys.asc> | C910 7A9B 55A4 DD77 062B 9731 B6E3 6A6A C54A CD59 |
 | Paulo Gomes | [@pjbgf](https://github.com/pjbgf) | <https://keybase.io/pjbgf/pgp_keys.asc> | 6C17 B119 D8C9 6768 4C80 E802 9995 2338 70E9 9BEE |
+| Matheus Pimenta | [@matheuscscp](https://github.com/matheuscscp) | <https://keybase.io/matheuscscp/pgp_keys.asc> | B404 C733 A16F 589B 592A 4FD7 86D8 78C7 79EB 9A95 |
 
 ### Handling
 


### PR DESCRIPTION
@fluxcd/core-maintainers 

### Applying as a Security Team member

**Process:**

- [x] You need to be a Maintainer to be able to apply
- [x] Set up your [Keybase](https://keybase.io) account
- [x] Make a PR against the `SECURITY.md` file in <https://github.com/fluxcd/.github> adding your contact information
- [x] @mention `@fluxcd/core-maintainers`
- [x] Have maintainers submit their vote by `+1`
- [x] Once all maintainers in repo have `+1` the PR will be reviewed by a member of the [core maintainers]

Adding new Security Team members is an [Unanimity decision](https://github.com/fluxcd/community/blob/main/GOVERNANCE.md#unanimity-decisions).

Once the above process has taken its course, make sure you

- [ ] Ping [CNCF Service Desk](https://cncfservicedesk.atlassian.net/) to get you added as [Security Team member].
- [x] Make a PR against [oss-fuzz](https://github.com/google/oss-fuzz/blob/e51830c2d428e672b405f9692adc82c57c1a6c5a/projects/fluxcd/project.yaml#L4-L9) to add your email.
- [ ] Ping fellow Security Team members to give you access to all the internal information.
