### PR TITLE
Remove `pjbgf` from the Security Team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,6 @@ Current Security Team members:
 | -- | -- | -- | -- |
 | Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155 |
 | Hidde Beydals | [@hiddeco](https://github.com/hiddeco) | <https://keybase.io/hidde/pgp_keys.asc> | C910 7A9B 55A4 DD77 062B 9731 B6E3 6A6A C54A CD59 |
-| Paulo Gomes | [@pjbgf](https://github.com/pjbgf) | <https://keybase.io/pjbgf/pgp_keys.asc> | 6C17 B119 D8C9 6768 4C80 E802 9995 2338 70E9 9BEE |
 | Matheus Pimenta | [@matheuscscp](https://github.com/matheuscscp) | <https://keybase.io/matheuscscp/pgp_keys.asc> | B404 C733 A16F 589B 592A 4FD7 86D8 78C7 79EB 9A95 |
 
 ### Handling


### PR DESCRIPTION
- [x] Removal from the Security Team within CNCF is being tracked under [CNCFSD-2847](https://cncfservicedesk.atlassian.net/servicedesk/customer/portal/1/CNCFSD-2847).
- [x] Removal from Security Team group in Keybase.
- [x] [Removal from oss-fuzz](https://github.com/google/oss-fuzz/pull/13369).